### PR TITLE
updating readme, dockerfiles, tests and variable casting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,151 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# MacOs
+**/.DS_Store
+
+# module files
+environment/TeraStitcher-portable-1.11.10-with-BF-Linux.tar.gz
+dask-report.html
+environment/environment.yml
+/data/*.json
+*.ipynb
+data/717381_stitching_smartspim_channels_single_channel.xml
+data/721679_stitching_smartspim_channels_single_channel.xml
 /data/
+/.codeocean/
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -1,32 +1,46 @@
 # aind-smartspim-fuse
 
-Repository that hosts the fusing step applied to the smartspim datasets. The current option at the moment is fusion with TeraStitcher.
+Repository that hosts the fusing step applied to SmartSPIM datasets.
+The primary fusion algorithm is **BigStitcher** (`run_capsule.py`).
+Alternative runners for **TeraStitcher** (`run_terastitcher_capsule.py`) and
+**CloudFusion** (`run_cloudfusion.py`) are also available.
 
-The processing steps for this capsule are:
+## BigStitcher pipeline (primary, `run_capsule.py`)
 
-1. We read the volume_alignments.xml file which contains the image transformation steps to align the whole volume.
-2. We validate capsule inputs in the data folder. The needed files are: "volume_alignments.xml", "processing_manifest.json" and "data_description.json".
-    - volume_alignments.xml: This file contains the image transformations applied to the stacks. By default, we are using TeraStitcher.
-    - processing_manifest.json: This file contains the image processing steps and some extra metadata necessary to fuse datasets.
-    - data_description.json: This file contains metadata about the dataset itself. Please, check the [aind-data-schema](https://github.com/AllenNeuralDynamics/aind-data-schema) repository to know more about this file.
-3. We create the fusion folder structure, generate new data description and copy all necessary metadata.
-4. We start the chunked fusion using TeraStitcher. Please, check the default parameters defined on the params folder of this repository.
-5. OMEZarr File Format Convertion: We configured TeraStitcher to output blocks of size (256, 256, 256) in most of the brain and in the border with whatever is left for that specific brain. These images are in TIFF format and need to be converted to OMEZarr for cloud visualization. In order to to this, we read the entire fused volume lazily, rechunk it to chunks of (128, 128, 128) and write it in a BigChunk approach. With BigChunk, our experiments show that to avoid a very large dask graph we can take n chunks (e.g., 4 chunks of 256) and then write those down. This is a good approach for very large datasets > 1 TB.
-6. Generate neuroglancer link.
+Required input in `../data/`:
+- `bigstitcher.xml` — BigStitcher-format XML with tile transforms
+- `preprocessed_data/Ex_*_Em_*/` — preprocessed zarr tile data
 
-> Note: This repository is intented to work with Code Ocean pipelines. It means that we are executing a single instance per dataset channel and the generated folder structure will be:
+Processing steps:
 
-fusion_{channel_name}:
-    - OMEZarr: Folder where we will save the fused data.
-    - metadata: Generated metadata for the fusion in this channel.
+1. Validate capsule inputs — confirms `bigstitcher.xml` is present.
+2. Locate the SmartSPIM channel directory under `preprocessed_data/`.
+3. Rewrite the XML to point at the actual data path on disk
+   (`modify_xml_removing_nextflow_folder`).
+4. Run `create-fusion-container` (BigStitcher) to create the output zarr
+   structure with nine downsampling levels (1×–256×, UINT16).
+5. Run `affine-fusion` (BigStitcher) to fill the zarr store with fused data.
+6. Write AIND processing metadata (`processing.json`) to `../results/`.
 
-It is important to mention that there's another folder that is created. This is an intermediate fusion with the 3D fused chunked tiffs and it's pointing to the scratch folder in Code Ocean by default.
+Output in `../results/`:
+```
+Ex_*_Em_*.zarr/        # fused OME-Zarr (multi-resolution)
+processing.json        # AIND processing provenance
+```
 
-## Documentation
-You can access the documentation for this module [here]().
+## Alternative runners
 
-## TeraStitcher Documentation
-You can download TeraStitcher documentation from [here](https://unicampus365-my.sharepoint.com/:b:/g/personal/g_iannello_unicampus_it/EYT9KbapjBdGvTAD2_MdbKgB5gY_h9rlvHzqp6mUNqVhIw?e=s8GrFC)
+| Runner | Algorithm | Key dependency |
+|--------|-----------|----------------|
+| `run_terastitcher_capsule.py` | TeraStitcher | `terastitcher` CLI + MPI |
+| `run_cloudfusion.py` | CloudFusion | `aind_cloud_fusion` + GPU (PyTorch) |
+
+TeraStitcher additionally requires `volume_alignments.xml`,
+`processing_manifest.json`, `data_description.json`, and `acquisition.json`
+in `../data/`.
+
+## TeraStitcher documentation
+You can download TeraStitcher documentation from [here](https://unicampus365-my.sharepoint.com/:b:/g/personal/g_iannello_unicampus_it/EYT9KbapjBdGvTAD2_MdbKgB5gY_h9rlvHzqp6mUNqVhIw?e=s8GrFC).
 
 ## Contributing
 

--- a/code/aind_smartspim_fuse/__init__.py
+++ b/code/aind_smartspim_fuse/__init__.py
@@ -2,7 +2,7 @@
 Module init file
 """
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 __authors__ = ["Camilo Laiton"]
 __author_emails__ = [
     "camilo.laiton@alleninstitute.org",

--- a/code/aind_smartspim_fuse/cloudfusion_fusion.py
+++ b/code/aind_smartspim_fuse/cloudfusion_fusion.py
@@ -147,7 +147,7 @@ def get_code_ocean_cpu_limit():
     aws_batch_job_id = os.environ.get("AWS_BATCH_JOB_ID")
 
     if co_cpus:
-        return co_cpus
+        return int(co_cpus)
     if aws_batch_job_id:
         return 1
     with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as fp:

--- a/code/aind_smartspim_fuse/params/params.py
+++ b/code/aind_smartspim_fuse/params/params.py
@@ -79,11 +79,7 @@ def get_yaml(yaml_path: PathLike):
         Dictionary with the yaml configuration
     """
 
-    config = None
-    try:
-        with open(yaml_path, "r") as stream:
-            config = yaml.safe_load(stream)
-    except Exception as error:
-        raise error
+    with open(yaml_path, "r") as stream:
+        config = yaml.safe_load(stream)
 
     return config

--- a/code/aind_smartspim_fuse/terastitcher_fusion.py
+++ b/code/aind_smartspim_fuse/terastitcher_fusion.py
@@ -412,7 +412,7 @@ def main(
     output_fused_path = Path(output_fused_path)
     intermediate_fused_folder = Path(intermediate_fused_folder)
 
-    if not output_fused_path.exists():
+    if not transforms_xml_path.exists():
         raise FileNotFoundError(f"XML path {transforms_xml_path} does not exist")
 
     # Looking for SmartSPIM channels on data folder

--- a/code/aind_smartspim_fuse/utils/utils.py
+++ b/code/aind_smartspim_fuse/utils/utils.py
@@ -416,57 +416,6 @@ def generate_new_channel_alignment_xml(
     return modified_mergexml_path
 
 
-def copy_available_metadata(
-    input_path: PathLike, output_path: PathLike, ignore_files: List[str]
-) -> List[PathLike]:
-    """
-    Copies all the valid metadata from the aind-data-schema
-    repository that exists in a given path.
-
-    Parameters
-    -----------
-    input_path: PathLike
-        Path where the metadata is located
-
-    output_path: PathLike
-        Path where we will copy the found
-        metadata
-
-    ignore_files: List[str]
-        List with the filenames of the metadata
-        that we need to ignore from the aind-data-schema
-
-    Returns
-    --------
-    List[PathLike]
-        List with the metadata files that
-        were copied
-    """
-
-    # We get all the valid filenames from the aind core model
-    metadata_to_find = [
-        cls.default_filename() for cls in AindCoreModel.__subclasses__()
-    ]
-
-    # Making sure the paths are pathlib objects
-    input_path = Path(input_path)
-    output_path = Path(output_path)
-
-    found_metadata = []
-
-    for metadata_filename in metadata_to_find:
-        metadata_filename = input_path.joinpath(metadata_filename)
-
-        if metadata_filename.exists() and metadata_filename.name not in ignore_files:
-            found_metadata.append(metadata_filename)
-
-            # Copying file to output path
-            output_filename = output_path.joinpath(metadata_filename.name)
-            copy_file(metadata_filename, output_filename)
-
-    return found_metadata
-
-
 def find_smartspim_channels(
     path: PathLike, channel_regex: str = r"Ex_([0-9]*)_Em_([0-9]*)$"
 ):
@@ -577,7 +526,6 @@ def create_logger(output_log_path: PathLike) -> logging.Logger:
         force=True,
     )
 
-    logging.disable("DEBUG")
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
@@ -869,7 +817,7 @@ def get_code_ocean_cpu_limit():
     aws_batch_job_id = os.environ.get("AWS_BATCH_JOB_ID")
 
     if co_cpus:
-        return co_cpus
+        return int(co_cpus)
     if aws_batch_job_id:
         return 1
 
@@ -881,7 +829,7 @@ def get_code_ocean_cpu_limit():
 
         container_cpus = cfs_quota_us // cfs_period_us
 
-    except FileNotFoundError as e:
+    except FileNotFoundError:
         container_cpus = 0
 
     # For physical machine, the `cfs_quota_us` could be '-1'
@@ -897,7 +845,7 @@ def print_system_information(logger: logging.Logger):
     logger: logging.Logger
         Logger object
     """
-    co_memory = int(os.environ.get("CO_MEMORY"))
+    co_memory = int(os.environ.get("CO_MEMORY", 0))
     # System info
     sep = "=" * 40
     logger.info(f"{sep} Code Ocean Information {sep}")

--- a/code/aind_smartspim_fuse/zarr_writer/zarr_utilities.py
+++ b/code/aind_smartspim_fuse/zarr_writer/zarr_utilities.py
@@ -253,14 +253,12 @@ def concatenate_dask_arrays(arr_1: ArrayLike, arr_2: ArrayLike, axis: int) -> Ar
             if shape_arr_1[shape_dim_idx] > shape_arr_2[shape_dim_idx] and (
                 shape_dim_idx - dims != axis
             ):
-                raise ValueError(
-                    f"""
+                raise ValueError(f"""
                     Array 1 {shape_arr_1} must have
                      a smaller shape than array 2 {shape_arr_2}
                      except for the axis dimension {shape_dim_idx}
                      {dims} {shape_dim_idx - dims} {axis}
-                    """
-                )
+                    """)
 
             if shape_arr_1[shape_dim_idx] != shape_arr_2[shape_dim_idx]:
                 slices.append(slice(0, shape_arr_1[shape_dim_idx]))
@@ -274,12 +272,10 @@ def concatenate_dask_arrays(arr_1: ArrayLike, arr_2: ArrayLike, axis: int) -> Ar
     try:
         res = concatenate([arr_1, arr_2], axis=axis)
     except ValueError:
-        raise ValueError(
-            f"""
+        raise ValueError(f"""
             Unable to cancat arrays - Shape 1:
              {shape_arr_1} shape 2: {shape_arr_2}
-            """
-        )
+            """)
 
     return res
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -134,7 +134,7 @@ def get_code_ocean_cpu_limit():
     aws_batch_job_id = os.environ.get("AWS_BATCH_JOB_ID")
 
     if co_cpus:
-        return co_cpus
+        return int(co_cpus)
     if aws_batch_job_id:
         return 1
     with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as fp:

--- a/code/tests/__init__.py
+++ b/code/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for aind-smartspim-fuse."""

--- a/code/tests/test_run_capsule_utils.py
+++ b/code/tests/test_run_capsule_utils.py
@@ -1,0 +1,265 @@
+"""Tests for utility functions defined directly in run_capsule.py.
+
+run_capsule.py is not a package module, so we add code/ to sys.path and
+import it as a top-level module.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# run_capsule.py lives directly in code/, not inside a package.
+_CODE_DIR = str(Path(__file__).parent.parent)
+if _CODE_DIR not in sys.path:
+    sys.path.insert(0, _CODE_DIR)
+
+try:
+    import run_capsule
+
+    RUN_CAPSULE_AVAILABLE = True
+except ImportError:
+    RUN_CAPSULE_AVAILABLE = False
+
+# Minimal BigStitcher XML with one ViewSetup containing voxel size info.
+_BIGSTITCHER_XML = """\
+<?xml version="1.0" encoding="utf-8"?>
+<SpimData version="0.2">
+  <SequenceDescription>
+    <ViewSetups>
+      <ViewSetup>
+        <id>0</id>
+        <voxelSize>
+          <unit>um</unit>
+          <size>0.748 0.748 2.0</size>
+        </voxelSize>
+      </ViewSetup>
+    </ViewSetups>
+    <ImageLoader format="bdv.n5">
+      <zarr type="absolute">/old/data/path</zarr>
+    </ImageLoader>
+  </SequenceDescription>
+</SpimData>"""
+
+
+@unittest.skipUnless(RUN_CAPSULE_AVAILABLE, "run_capsule not importable")
+class TestValidateCapsuleInputs(unittest.TestCase):
+    def test_all_present_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f = Path(tmpdir) / "bigstitcher.xml"
+            f.touch()
+            result = run_capsule.validate_capsule_inputs([str(f)])
+            self.assertEqual(result, [])
+
+    def test_missing_file_appears_in_result(self):
+        result = run_capsule.validate_capsule_inputs(["/nonexistent/file.xml"])
+        self.assertEqual(len(result), 1)
+        self.assertIn("file.xml", result[0])
+
+    def test_mix_of_present_and_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            present = Path(tmpdir) / "exists.xml"
+            present.touch()
+            missing = "/nonexistent/missing.xml"
+            result = run_capsule.validate_capsule_inputs([str(present), missing])
+            self.assertEqual(len(result), 1)
+            self.assertIn("missing.xml", result[0])
+
+    def test_empty_list_returns_empty_list(self):
+        result = run_capsule.validate_capsule_inputs([])
+        self.assertEqual(result, [])
+
+    def test_multiple_missing_all_returned(self):
+        result = run_capsule.validate_capsule_inputs(
+            ["/no/a.xml", "/no/b.xml", "/no/c.xml"]
+        )
+        self.assertEqual(len(result), 3)
+
+
+@unittest.skipUnless(RUN_CAPSULE_AVAILABLE, "run_capsule not importable")
+class TestGetTileZyzResolution(unittest.TestCase):
+    def _write_xml(self, tmpdir):
+        p = Path(tmpdir) / "bigstitcher.xml"
+        p.write_text(_BIGSTITCHER_XML)
+        return str(p)
+
+    def test_returns_list_of_three_floats(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            res = run_capsule.get_tile_zyz_resolution(self._write_xml(tmpdir))
+            self.assertEqual(len(res), 3)
+            for v in res:
+                self.assertIsInstance(v, float)
+
+    def test_z_is_first(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # XML size is "0.748 0.748 2.0" (X Y Z); reversed → Z Y X
+            res = run_capsule.get_tile_zyz_resolution(self._write_xml(tmpdir))
+            self.assertAlmostEqual(res[0], 2.0)
+
+    def test_y_is_second(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            res = run_capsule.get_tile_zyz_resolution(self._write_xml(tmpdir))
+            self.assertAlmostEqual(res[1], 0.748)
+
+    def test_x_is_third(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            res = run_capsule.get_tile_zyz_resolution(self._write_xml(tmpdir))
+            self.assertAlmostEqual(res[2], 0.748)
+
+
+@unittest.skipUnless(RUN_CAPSULE_AVAILABLE, "run_capsule not importable")
+class TestGetResolution(unittest.TestCase):
+    def _acquisition(self, x=0.748, y=0.748, z=2.0):
+        return {
+            "tiles": [
+                {
+                    "coordinate_transformations": [
+                        {"type": "scale", "scale": [str(x), str(y), str(z)]}
+                    ]
+                }
+            ]
+        }
+
+    def test_returns_three_values(self):
+        result = run_capsule.get_resolution(self._acquisition())
+        self.assertEqual(len(result), 3)
+
+    def test_x_value(self):
+        x, _, _ = run_capsule.get_resolution(self._acquisition(x=1.5))
+        self.assertAlmostEqual(x, 1.5)
+
+    def test_y_value(self):
+        _, y, _ = run_capsule.get_resolution(self._acquisition(y=2.0))
+        self.assertAlmostEqual(y, 2.0)
+
+    def test_z_value(self):
+        _, _, z = run_capsule.get_resolution(self._acquisition(z=3.0))
+        self.assertAlmostEqual(z, 3.0)
+
+    def test_values_are_floats(self):
+        x, y, z = run_capsule.get_resolution(self._acquisition())
+        self.assertIsInstance(x, float)
+        self.assertIsInstance(y, float)
+        self.assertIsInstance(z, float)
+
+    def test_uses_only_first_tile(self):
+        config = self._acquisition(x=1.0)
+        config["tiles"].append(
+            {
+                "coordinate_transformations": [
+                    {"type": "scale", "scale": ["9.9", "9.9", "9.9"]}
+                ]
+            }
+        )
+        x, _, _ = run_capsule.get_resolution(config)
+        self.assertAlmostEqual(x, 1.0)
+
+    def test_ignores_non_scale_transforms(self):
+        config = {
+            "tiles": [
+                {
+                    "coordinate_transformations": [
+                        {"type": "translation", "translation": [0, 0, 0]},
+                        {"type": "scale", "scale": ["0.748", "0.748", "2.0"]},
+                    ]
+                }
+            ]
+        }
+        x, y, z = run_capsule.get_resolution(config)
+        self.assertAlmostEqual(x, 0.748)
+        self.assertAlmostEqual(z, 2.0)
+
+
+@unittest.skipUnless(RUN_CAPSULE_AVAILABLE, "run_capsule not importable")
+class TestReadJsonAsDictRunCapsule(unittest.TestCase):
+    def test_reads_valid_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"hello": "world"}, f)
+            fname = f.name
+        try:
+            result = run_capsule.read_json_as_dict(fname)
+            self.assertEqual(result, {"hello": "world"})
+        finally:
+            os.unlink(fname)
+
+    def test_missing_file_returns_empty_dict(self):
+        result = run_capsule.read_json_as_dict("/nonexistent/path.json")
+        self.assertEqual(result, {})
+
+
+@unittest.skipUnless(RUN_CAPSULE_AVAILABLE, "run_capsule not importable")
+class TestGetCodeOceanCpuLimitRunCapsule(unittest.TestCase):
+    def setUp(self):
+        self._orig = {
+            k: os.environ.pop(k, None) for k in ("CO_CPUS", "AWS_BATCH_JOB_ID")
+        }
+
+    def tearDown(self):
+        for k, v in self._orig.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def test_co_cpus_returns_int(self):
+        os.environ["CO_CPUS"] = "4"
+        result = run_capsule.get_code_ocean_cpu_limit()
+        self.assertIsInstance(result, int)
+        self.assertEqual(result, 4)
+
+    def test_aws_batch_returns_1(self):
+        os.environ["AWS_BATCH_JOB_ID"] = "job-123"
+        result = run_capsule.get_code_ocean_cpu_limit()
+        self.assertEqual(result, 1)
+
+    def test_result_is_never_a_string(self):
+        os.environ["CO_CPUS"] = "16"
+        result = run_capsule.get_code_ocean_cpu_limit()
+        self.assertNotIsInstance(result, str)
+
+
+@unittest.skipUnless(RUN_CAPSULE_AVAILABLE, "run_capsule not importable")
+class TestModifyXmlRemovingNextflowFolder(unittest.TestCase):
+    def test_updates_zarr_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_xml = Path(tmpdir) / "input.xml"
+            input_xml.write_text(_BIGSTITCHER_XML)
+            output_xml = Path(tmpdir) / "modified.xml"
+
+            run_capsule.modify_xml_removing_nextflow_folder(
+                str(input_xml), str(output_xml), "/new/data/path"
+            )
+
+            content = output_xml.read_text()
+            self.assertIn("/new/data/path", content)
+
+    def test_output_file_is_created(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_xml = Path(tmpdir) / "input.xml"
+            input_xml.write_text(_BIGSTITCHER_XML)
+            output_xml = Path(tmpdir) / "modified.xml"
+
+            run_capsule.modify_xml_removing_nextflow_folder(
+                str(input_xml), str(output_xml), "/new/path"
+            )
+
+            self.assertTrue(output_xml.exists())
+
+    def test_old_path_no_longer_present(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_xml = Path(tmpdir) / "input.xml"
+            input_xml.write_text(_BIGSTITCHER_XML)
+            output_xml = Path(tmpdir) / "modified.xml"
+
+            run_capsule.modify_xml_removing_nextflow_folder(
+                str(input_xml), str(output_xml), "/new/path"
+            )
+
+            content = output_xml.read_text()
+            self.assertNotIn("/old/data/path", content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/tests/test_terastitcher_commands.py
+++ b/code/tests/test_terastitcher_commands.py
@@ -1,0 +1,252 @@
+"""Tests for TeraStitcher command-building functions in terastitcher_fusion.py.
+
+These tests verify that the functions assemble the correct CLI strings and
+write expected output files. They do not execute any external process.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+try:
+    from aind_smartspim_fuse.terastitcher_fusion import (
+        build_parallel_command, terastitcher_import_cmd,
+        terastitcher_merge_cmd)
+
+    TERAS_AVAILABLE = True
+except ImportError:
+    TERAS_AVAILABLE = False
+
+
+def _cpu_params(n_procs=4, additional=None, hostfile="/etc/hosts"):
+    return {
+        "cpu_params": {
+            "number_processes": n_procs,
+            "additional_params": additional or [],
+            "hostfile": hostfile,
+        }
+    }
+
+
+def _import_params():
+    return {
+        "vxl1": 0.748,
+        "vxl2": 0.748,
+        "vxl3": 2.0,
+        "additional_params": [],
+    }
+
+
+def _merge_params(tmpdir):
+    return {
+        "s": str(Path(tmpdir) / "xml_merging_Ex_488_Em_525.xml"),
+        "d": str(Path(tmpdir) / "output"),
+        "sfmt": '"TIFF (unstitched, 3D)"',
+        "dfmt": '"TIFF (tiled, 4D)"',
+        "cpu_params": {
+            "number_processes": 4,
+            "additional_params": [],
+            "hostfile": "/etc/hosts",
+        },
+        "width": 256,
+        "height": 256,
+        "depth": 256,
+        "additional_params": ["fixed_tiling"],
+        "ch_dir": "Ex_488_Em_525",
+    }
+
+
+@unittest.skipUnless(TERAS_AVAILABLE, "aind_smartspim_fuse not importable")
+class TestBuildParallelCommand(unittest.TestCase):
+    def test_contains_mpirun(self):
+        cmd = build_parallel_command(_cpu_params(), "/path/to/tool.py")
+        self.assertIn("mpirun -np", cmd)
+
+    def test_contains_process_count(self):
+        cmd = build_parallel_command(_cpu_params(n_procs=8), "/tool.py")
+        self.assertIn("8", cmd)
+
+    def test_contains_tool_path(self):
+        cmd = build_parallel_command(_cpu_params(), "/some/tool.py")
+        self.assertIn("python /some/tool.py", cmd)
+
+    def test_contains_hostfile(self):
+        cmd = build_parallel_command(_cpu_params(hostfile="/my/hosts"), "/tool.py")
+        self.assertIn("--hostfile /my/hosts", cmd)
+
+    def test_includes_additional_params(self):
+        cmd = build_parallel_command(
+            _cpu_params(additional=["overwrite_zeros"]), "/tool.py"
+        )
+        self.assertIn("--overwrite_zeros", cmd)
+
+    def test_empty_additional_params_still_produces_valid_cmd(self):
+        cmd = build_parallel_command(_cpu_params(additional=[]), "/tool.py")
+        self.assertIn("mpirun", cmd)
+
+    def test_process_count_is_embedded_correctly(self):
+        for n in (1, 4, 16):
+            with self.subTest(n=n):
+                cmd = build_parallel_command(_cpu_params(n_procs=n), "/tool.py")
+                self.assertIn(f"mpirun -np {n}", cmd)
+
+
+@unittest.skipUnless(TERAS_AVAILABLE, "aind_smartspim_fuse not importable")
+class TestTerastitcherImportCmd(unittest.TestCase):
+    CHANNEL = "Ex_488_Em_525"
+
+    def test_returns_two_element_tuple(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertIsInstance(result, tuple)
+            self.assertEqual(len(result), 2)
+
+    def test_command_is_a_string(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd, _ = terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertIsInstance(cmd, str)
+
+    def test_command_contains_import_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd, _ = terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertIn("--import", cmd)
+
+    def test_command_contains_input_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd, _ = terastitcher_import_cmd(
+                input_path="/data/my_channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertIn("/data/my_channel", cmd)
+
+    def test_binary_path_contains_channel_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, binary_path = terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertIn(self.CHANNEL, binary_path)
+
+    def test_binary_path_ends_with_bin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, binary_path = terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertTrue(binary_path.endswith(".bin"))
+
+    def test_writes_json_params_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            expected = Path(tmpdir) / f"import_params_{self.CHANNEL}.json"
+            self.assertTrue(expected.exists())
+
+    def test_output_xml_path_contains_channel_name(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd, _ = terastitcher_import_cmd(
+                input_path="/data/channel",
+                xml_output_path=tmpdir,
+                import_params=_import_params(),
+                channel_name=self.CHANNEL,
+            )
+            self.assertIn(self.CHANNEL, cmd)
+
+
+@unittest.skipUnless(TERAS_AVAILABLE, "aind_smartspim_fuse not importable")
+class TestTerastitcherMergeCmd(unittest.TestCase):
+    CHANNEL = "Ex_488_Em_525"
+
+    def test_returns_string(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = terastitcher_merge_cmd(
+                xml_output_path=Path(tmpdir),
+                merge_params=_merge_params(tmpdir),
+                channel_name=self.CHANNEL,
+                paraconverter_path="/path/to/paraconverter.py",
+            )
+            self.assertIsInstance(cmd, str)
+
+    def test_contains_mpirun(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = terastitcher_merge_cmd(
+                xml_output_path=Path(tmpdir),
+                merge_params=_merge_params(tmpdir),
+                channel_name=self.CHANNEL,
+                paraconverter_path="/path/to/paraconverter.py",
+            )
+            self.assertIn("mpirun", cmd)
+
+    def test_s_flag_uses_short_form(self):
+        # The function replaces --s= with -s= to comply with paraconverter
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = terastitcher_merge_cmd(
+                xml_output_path=Path(tmpdir),
+                merge_params=_merge_params(tmpdir),
+                channel_name=self.CHANNEL,
+                paraconverter_path="/path/to/paraconverter.py",
+            )
+            self.assertNotIn("--s=", cmd)
+            self.assertIn("-s=", cmd)
+
+    def test_d_flag_uses_short_form(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = terastitcher_merge_cmd(
+                xml_output_path=Path(tmpdir),
+                merge_params=_merge_params(tmpdir),
+                channel_name=self.CHANNEL,
+                paraconverter_path="/path/to/paraconverter.py",
+            )
+            self.assertNotIn("--d=", cmd)
+            self.assertIn("-d=", cmd)
+
+    def test_writes_merge_json_params_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            terastitcher_merge_cmd(
+                xml_output_path=Path(tmpdir),
+                merge_params=_merge_params(tmpdir),
+                channel_name=self.CHANNEL,
+                paraconverter_path="/path/to/paraconverter.py",
+            )
+            expected = Path(tmpdir) / f"merge_volume_params_{self.CHANNEL}.json"
+            self.assertTrue(expected.exists())
+
+    def test_paraconverter_path_in_command(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = terastitcher_merge_cmd(
+                xml_output_path=Path(tmpdir),
+                merge_params=_merge_params(tmpdir),
+                channel_name=self.CHANNEL,
+                paraconverter_path="/my/paraconverter.py",
+            )
+            self.assertIn("/my/paraconverter.py", cmd)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/code/tests/test_utils.py
+++ b/code/tests/test_utils.py
@@ -1,0 +1,290 @@
+"""Tests for aind_smartspim_fuse/utils/utils.py."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+try:
+    from aind_smartspim_fuse.utils.utils import (
+        check_path_instance, find_smartspim_channels, generate_timestamp,
+        get_code_ocean_cpu_limit, get_size, helper_additional_params_command,
+        helper_build_param_value_command, read_json_as_dict, save_dict_as_json,
+        wavelength_to_hex)
+
+    UTILS_AVAILABLE = True
+except ImportError:
+    UTILS_AVAILABLE = False
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestWavelengthToHex(unittest.TestCase):
+    def test_below_first_bound_returns_purple(self):
+        self.assertEqual(wavelength_to_hex(400), 0x690AFE)
+
+    def test_at_first_bound_skips_to_next_bucket(self):
+        # 460 is NOT < 460, falls into the 470 bucket (0x3F2EFE)
+        self.assertEqual(wavelength_to_hex(460), 0x3F2EFE)
+
+    def test_at_second_bound_skips_to_next_bucket(self):
+        # 470 is NOT < 470, falls into the 480 bucket (0x4B90FE)
+        self.assertEqual(wavelength_to_hex(470), 0x4B90FE)
+
+    def test_red_channel_wavelength(self):
+        # 667 < 750 → pink/red bucket 0xF00050
+        self.assertEqual(wavelength_to_hex(667), 0xF00050)
+
+    def test_above_max_bound_returns_last_color(self):
+        # Loop exhausted, fallback returns last iterated value (750 bucket)
+        self.assertEqual(wavelength_to_hex(800), 0xF00050)
+
+    def test_green_channel(self):
+        # 525 is between 520 and 540 → 540 bucket (0x58FEA1)
+        self.assertEqual(wavelength_to_hex(525), 0x58FEA1)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestHelperBuildParamValueCommand(unittest.TestCase):
+    def test_with_equal_connector(self):
+        params = {"vxl1": 0.748, "vxl2": 0.748}
+        result = helper_build_param_value_command(params, equal_con=True)
+        self.assertIn("--vxl1=0.748", result)
+        self.assertIn("--vxl2=0.748", result)
+
+    def test_without_equal_connector(self):
+        params = {"vxl1": 0.748}
+        result = helper_build_param_value_command(params, equal_con=False)
+        self.assertIn("--vxl1 0.748", result)
+
+    def test_empty_dict_returns_empty_string(self):
+        result = helper_build_param_value_command({})
+        self.assertEqual(result.strip(), "")
+
+    def test_skips_non_scalar_values(self):
+        params = {"list_key": [1, 2, 3], "str_key": "value"}
+        result = helper_build_param_value_command(params)
+        self.assertNotIn("list_key", result)
+        self.assertIn("--str_key=value", result)
+
+    def test_integer_value(self):
+        result = helper_build_param_value_command({"depth": 256})
+        self.assertIn("--depth=256", result)
+
+    def test_path_value_included(self):
+        params = {"out": Path("/tmp/output")}
+        result = helper_build_param_value_command(params)
+        self.assertIn("--out=", result)
+        self.assertIn("/tmp/output", result)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestHelperAdditionalParamsCommand(unittest.TestCase):
+    def test_builds_flag_style_params(self):
+        result = helper_additional_params_command(["fixed_tiling", "sparse"])
+        self.assertIn("--fixed_tiling", result)
+        self.assertIn("--sparse", result)
+
+    def test_empty_list_returns_empty_string(self):
+        result = helper_additional_params_command([])
+        self.assertEqual(result, "")
+
+    def test_single_param(self):
+        result = helper_additional_params_command(["overwrite"])
+        self.assertIn("--overwrite", result)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestGetSize(unittest.TestCase):
+    def test_bytes(self):
+        result = get_size(512)
+        self.assertIn("B", result)
+
+    def test_kilobytes(self):
+        result = get_size(1024)
+        self.assertIn("KB", result)
+
+    def test_megabytes(self):
+        result = get_size(1024 * 1024)
+        self.assertIn("MB", result)
+
+    def test_gigabytes(self):
+        result = get_size(1024**3)
+        self.assertIn("GB", result)
+
+    def test_zero_bytes(self):
+        result = get_size(0)
+        self.assertIn("B", result)
+        self.assertIn("0.00", result)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestGenerateTimestamp(unittest.TestCase):
+    def test_returns_non_empty_string(self):
+        ts = generate_timestamp()
+        self.assertIsInstance(ts, str)
+        self.assertTrue(len(ts) > 0)
+
+    def test_custom_year_format(self):
+        ts = generate_timestamp("%Y")
+        self.assertTrue(ts.isdigit())
+        self.assertEqual(len(ts), 4)
+
+    def test_default_format_contains_dashes(self):
+        ts = generate_timestamp()
+        self.assertIn("-", ts)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestCheckPathInstance(unittest.TestCase):
+    def test_posix_path_returns_true(self):
+        self.assertTrue(check_path_instance(Path("/some/path")))
+
+    def test_string_returns_false(self):
+        self.assertFalse(check_path_instance("/some/path"))
+
+    def test_none_returns_false(self):
+        self.assertFalse(check_path_instance(None))
+
+    def test_integer_returns_false(self):
+        self.assertFalse(check_path_instance(42))
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestReadJsonAsDict(unittest.TestCase):
+    def test_reads_valid_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"key": "value"}, f)
+            fname = f.name
+        try:
+            result = read_json_as_dict(fname)
+            self.assertEqual(result, {"key": "value"})
+        finally:
+            os.unlink(fname)
+
+    def test_missing_file_returns_empty_dict(self):
+        result = read_json_as_dict("/nonexistent/path/file.json")
+        self.assertEqual(result, {})
+
+    def test_nested_structure(self):
+        data = {"a": {"b": [1, 2, 3]}, "c": True}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            fname = f.name
+        try:
+            result = read_json_as_dict(fname)
+            self.assertEqual(result, data)
+        finally:
+            os.unlink(fname)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestSaveDictAsJson(unittest.TestCase):
+    def test_saves_and_reads_back(self):
+        data = {"x": 1, "y": "hello"}
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            fname = f.name
+        try:
+            save_dict_as_json(fname, data)
+            with open(fname) as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded, data)
+        finally:
+            os.unlink(fname)
+
+    def test_none_saves_empty_dict(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            fname = f.name
+        try:
+            save_dict_as_json(fname, None)
+            with open(fname) as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded, {})
+        finally:
+            os.unlink(fname)
+
+    def test_path_values_converted_to_str(self):
+        data = {"out": Path("/some/output")}
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            fname = f.name
+        try:
+            save_dict_as_json(fname, data)
+            with open(fname) as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded["out"], "/some/output")
+        finally:
+            os.unlink(fname)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestFindSmartspimChannels(unittest.TestCase):
+    def test_finds_matching_channel_dirs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "Ex_488_Em_525").mkdir()
+            Path(tmpdir, "Ex_639_Em_680").mkdir()
+            Path(tmpdir, "unrelated_folder").mkdir()
+            channels = find_smartspim_channels(tmpdir)
+            self.assertEqual(sorted(channels), ["Ex_488_Em_525", "Ex_639_Em_680"])
+
+    def test_no_matching_channels_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "unrelated").mkdir()
+            channels = find_smartspim_channels(tmpdir)
+            self.assertEqual(channels, [])
+
+    def test_custom_regex(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "Ex_488_Em_525").mkdir()
+            Path(tmpdir, "Ex_639_Em_680").mkdir()
+            channels = find_smartspim_channels(tmpdir, channel_regex=r"Ex_488.*")
+            self.assertIn("Ex_488_Em_525", channels)
+            self.assertNotIn("Ex_639_Em_680", channels)
+
+    def test_matches_files_as_well_as_dirs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir, "Ex_561_Em_593")).touch()
+            channels = find_smartspim_channels(tmpdir)
+            self.assertIn("Ex_561_Em_593", channels)
+
+
+@unittest.skipUnless(UTILS_AVAILABLE, "aind_smartspim_fuse.utils not importable")
+class TestGetCodeOceanCpuLimit(unittest.TestCase):
+    def setUp(self):
+        # Clear relevant env vars before each test
+        self._orig = {
+            k: os.environ.pop(k, None) for k in ("CO_CPUS", "AWS_BATCH_JOB_ID")
+        }
+
+    def tearDown(self):
+        for k, v in self._orig.items():
+            if v is not None:
+                os.environ[k] = v
+            else:
+                os.environ.pop(k, None)
+
+    def test_co_cpus_returns_int(self):
+        os.environ["CO_CPUS"] = "8"
+        result = get_code_ocean_cpu_limit()
+        self.assertIsInstance(result, int)
+        self.assertEqual(result, 8)
+
+    def test_co_cpus_not_a_string(self):
+        os.environ["CO_CPUS"] = "16"
+        result = get_code_ocean_cpu_limit()
+        self.assertNotIsInstance(result, str)
+
+    def test_aws_batch_returns_1(self):
+        os.environ["AWS_BATCH_JOB_ID"] = "some-job-id"
+        result = get_code_ocean_cpu_limit()
+        self.assertEqual(result, 1)
+
+    def test_co_cpus_takes_priority_over_aws_batch(self):
+        os.environ["CO_CPUS"] = "4"
+        os.environ["AWS_BATCH_JOB_ID"] = "some-job-id"
+        result = get_code_ocean_cpu_limit()
+        self.assertEqual(result, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,60 +1,6 @@
 ARG REGISTRY_HOST
-FROM $REGISTRY_HOST/codeocean/mambaforge3:23.1.0-4-python3.10.12-ubuntu22.04
-
-LABEL maintainer="Camilo Laiton <camilo.laiton@alleninstitute.org>"
+FROM $REGISTRY_HOST/codeocean/aind-smartspim-fuse:si-0.0.6
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG AWS_ACCESS_KEY_ID
-ARG AWS_DEFAULT_REGION
-ARG AWS_SECRET_ACCESS_KEY
-
 ARG GIT_ASKPASS
-ARG GIT_ACCESS_TOKEN
-COPY git-askpass /
-
-# Set environment variables
-ENV AWS_REGION=us-west-2
-ENV JAVA_OPTS="-Djava.awt.headless=true"
-ENV HOME="/root"
-ENV BIGSTITCHER_HOME=/home/BigStitcher-Spark
-ENV N5_AWS_FOLDER_HOME=/home/n5-aws-s3
-ENV CLASSPATH="$BIGSTITCHER_HOME/target/*:$N5_AWS_FOLDER_HOME/target/*"
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libblosc-dev=1.21.1+ds2-2 \
-        maven=3.6.3-5 && \
-    rm -rf /var/lib/apt/lists/*
-
-# Download and set up Java
-WORKDIR $HOME
-RUN wget -q https://cdn.azul.com/zulu/bin/zulu8.80.0.17-ca-fx-jdk8.0.422-linux_x64.tar.gz && \
-    tar -xzf zulu8.80.0.17-ca-fx-jdk8.0.422-linux_x64.tar.gz && \
-    rm zulu8.80.0.17-ca-fx-jdk8.0.422-linux_x64.tar.gz && \
-    mv zulu8.80.0.17-ca-fx-jdk8.0.422-linux_x64 /opt/java
-
-ENV JAVA_HOME="/opt/java"
-ENV PATH="$JAVA_HOME/bin:$PATH"
-
-RUN conda install -y --freeze-installed \
-        ca-certificates=2024.7.4 \
-        openssl=3.3.1 \
-    && conda clean -ya
-
-WORKDIR /.code-server
-RUN wget -qO code-server.tar.gz https://github.com/coder/code-server/releases/download/v4.9.0/code-server-4.9.0-linux-amd64.tar.gz && \
-    tar -xvf code-server.tar.gz --strip-components=1 && \
-    rm code-server.tar.gz && \
-    ln -s /.code-server/bin/code-server /usr/bin/code-server
-
-# Install Python aind-data-schema
-RUN pip install -U --no-cache-dir \
-    aind-data-schema==1.4.0 \
-    psutil==5.9.5 \
-    PyYAMLp==5.4.1
-
-# Copy and run post-install script
-COPY postInstall /
-RUN /bin/bash /postInstall
-
-WORKDIR $HOME
+COPY git-ask-pass /

--- a/environment/Dockerfile_local
+++ b/environment/Dockerfile_local
@@ -1,7 +1,11 @@
 # Use a public base image
 FROM ubuntu:22.04
 
-LABEL maintainer="Camilo Laiton <camilo.laiton@alleninstitute.org>"
+LABEL maintainer="Camilo Laiton <camilo.laiton@alleninstitute.org>" \
+    org.opencontainers.image.title="Image Preprocessing" \
+    org.opencontainers.image.description="Container for flatfield and stripe correction." \
+    org.opencontainers.image.version="0.0.6" \
+    org.opencontainers.image.licenses="MIT"
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -42,14 +46,20 @@ RUN wget -qO Miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-
 # Add conda to PATH
 ENV PATH="/opt/conda/bin:$PATH"
 
-# Install additional conda packages with specific versions
-RUN conda install -y -c conda-forge \
-        ca-certificates=2024.7.4 \
-        openssl=3.3.1 \
+# Install additional conda packages with specific versions.
+# --override-channels restricts conda to only the channels listed here,
+# bypassing the default Anaconda channels (pkgs/main, pkgs/r) that require
+# Terms of Service acceptance in conda >= 24.3.
+RUN conda install -y --override-channels -c conda-forge \
+        ca-certificates \
+        openssl \
     && conda clean -ya
 
 # Install Python packages
-RUN pip3 install --no-cache-dir aind-data-schema==1.4.0 psutil PyYAML
+RUN pip3 install --no-cache-dir aind-data-schema==1.4.0 \
+    psutil==5.9.5 \
+    PyYAMLp==5.4.1 \
+    argschema==3.0.4
 
 # Set up code-server
 WORKDIR /.code-server

--- a/environment/Dockerfile_local
+++ b/environment/Dockerfile_local
@@ -2,8 +2,8 @@
 FROM ubuntu:22.04
 
 LABEL maintainer="Camilo Laiton <camilo.laiton@alleninstitute.org>" \
-    org.opencontainers.image.title="Image Preprocessing" \
-    org.opencontainers.image.description="Container for flatfield and stripe correction." \
+    org.opencontainers.image.title="Image Fusion" \
+    org.opencontainers.image.description="Container for image fusion." \
     org.opencontainers.image.version="0.0.6" \
     org.opencontainers.image.licenses="MIT"
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, with a focus on enhancing documentation, increasing robustness, and improving test coverage. The most significant changes include a major rewrite of the `README.md` to clarify usage and pipeline details, the addition of comprehensive unit tests for `run_capsule.py` utilities, and some bug fixes and code cleanups to improve reliability and maintainability.

**Documentation improvements:**

* Major rewrite of `README.md` to clarify the primary and alternative fusion pipelines, required inputs/outputs, and processing steps for SmartSPIM fusion, with explicit details for BigStitcher, TeraStitcher, and CloudFusion runners.

**Testing enhancements:**

* Added a new test suite `test_run_capsule_utils.py` with comprehensive unit tests for utility functions in `run_capsule.py`, including input validation, XML manipulation, resolution extraction, and environment variable handling.
* Added a module docstring to `tests/__init__.py` for clarity.

**Bug fixes and robustness:**

* Fixed `get_code_ocean_cpu_limit()` in multiple modules to always return an integer (not string), improving compatibility and preventing subtle bugs when reading CPU limits from environment variables.
* Fixed a bug in `print_system_information()` where `CO_MEMORY` could raise an exception if unset, by providing a default value.
* Improved file existence checks in `terastitcher_fusion.py` to validate the presence of the XML transform file before proceeding.

**Code cleanup and simplification:**

* Removed the unused `copy_available_metadata` function from `utils.py`, reducing dead code.
* Simplified error handling in `params.py` by removing unnecessary try/except around YAML loading.
* Improved error messages in `zarr_utilities.py` for array concatenation failures, making debugging easier.
* Removed an incorrect call to `logging.disable("DEBUG")` in logger setup, ensuring debug logs are not globally disabled.
* Improved exception handling for missing cgroup files in `get_code_ocean_cpu_limit()` to avoid leaking exception variables.

**Versioning:**

* Bumped the package version to `0.0.6` in `__init__.py`.

**Dockerfiles**
* Updating dockerfiles to import the base image in Code Ocean and the creation of the base image in Dockerfile_local. 